### PR TITLE
Fix profile stats spacing and proposal for heading size fix

### DIFF
--- a/src/RLOTExperimental.user.css
+++ b/src/RLOTExperimental.user.css
@@ -3920,7 +3920,7 @@
     .profile-header .header-caption .header-details .details-info {
         position: absolute;
         bottom: 0;
-        width: 40%;
+        width: 36%;
         display: block
     }
     .profile-header .header-caption .header-details .details-info li {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/dcf75550-121c-4923-9bb8-3ca1bed986fa)

It's supposed to be 36% width not 40%. Please review and make sure this is the same in 2019.

Also, on profiles, the name heading is supposed to be 30px, not 36px. I have not modified this in case it messes something else up (trying to modify it as is changes the font size of the groups heading for example). This is because Roblox changed profile headings to H1 instead of H2 (as that was used before).